### PR TITLE
Develop

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,6 +15,9 @@
 		"ms-iot.vscode-ros"
 	],
 	"runArgs": [
+		"--cap-add=SYS_PTRACE",
+		"--security-opt",
+		"seccomp=unconfined",
 		"--rm",
 		"--network",
 		"host"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "python.autoComplete.extraPaths": [
+        "/home/sonia/base_lib_ws/devel/lib/python2.7/dist-packages",
+        "/opt/ros/melodic/lib/python2.7/dist-packages"
+    ]
+}

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>provider_hydrophone</name>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <description>
     The provider_hydrophone is responsible to get data from hydrophone
   </description>

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <name>provider_hydrophone</name>
-  <version>1.0.1</version>
+  <version>1.0.0</version>
   <description>
     The provider_hydrophone is responsible to get data from hydrophone
   </description>


### PR DESCRIPTION
## Description
 - Add additional `settings.json` to resolve python container in remote debuging
 - Add ptrace arguments to `devcontainer.json` to grant full access in container to cpp debugger  

## How has this been tested ?
Locally tested with vscode remote-container and ROS extensions

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings